### PR TITLE
smal fix for terminal multiplexing lovers

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -522,7 +522,9 @@
     " }
 
     " Terminal {
-        set term=xterm-256color
+        if  !(&term =~ 'screen-256color')
+            set term=xterm-256color
+        endif
         set t_Co=256
 
         if &term =~ 'xterm'


### PR DESCRIPTION
screen or tmux might break when treated like xterm. The official tmux
documentation explicitly advises against setting TERM to anything other
than screen or screen-256color. This patch skips setting the term
variable if term contains screen-256color.
